### PR TITLE
Could not save node config

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -8,34 +8,8 @@ class Node < ActiveRecord::Base
   validate :config_is_json_format
 
   after_initialize do
-    self.user = 'root'
-    self.config = <<END
-{
-  // Default user created by role machine. This user is required for rails-stack.
-  //"user": ["deployer"],
-
-  // Example of Overiding default value for nginx package
-  // "nginx": {
-  //  "worker_processes": 1
-  // },
-  //
-  // "ruby": {
-  //   "version": "2.1.0"
-  // },
-  //
-  // "run_list": [
-  // This recipe required for cookbooks that depends on data-bags serach functionality.
-  //  "recipe[chef-solo-search]",
-
-  // Setup basic required users, tools and packages for all type of machines
-  // "role[machine]",
-  // "role[application]",
-  // "role[nginx]",
-  // "role[pg_ubuntu]",
-  // "recipe[memcached]"
-  // ]
-}
-END
+    self.user   ||= 'root'
+    self.config ||= default_config
   end
 
   def parameterized_name
@@ -52,4 +26,16 @@ END
     errors[:config] << 'not in json format' unless JSON.parse(self.config)
   end
 
+  private
+
+  def default_config
+<<END
+{
+  // You can find examples in: http://bit.ly/1kDPBpu
+  "run_list": [
+    "recipe[chef-solo-search]"
+  ]
+}
+END
+  end
 end

--- a/test/controllers/nodes_controller_test.rb
+++ b/test/controllers/nodes_controller_test.rb
@@ -55,10 +55,22 @@ class NodesControllerTest < ActionController::TestCase
     assert_redirected_to root_url
   end
 
-  test 'should update node' do
+  test 'should update node name' do
     patch :update, id: @node, node: { name: 'Sweet' }
     @node.reload
     assert_equal 'Sweet', @node.name
+  end
+
+  test 'should update node user' do
+    patch :update, id: @node, node: { user: 'admin' }
+    @node.reload
+    assert_equal 'admin', @node.user
+  end
+
+  def test_update_node_config
+    patch :update, id: @node, node: { config: '{"new_attribute": "Time"}' }
+    @node.reload
+    assert_equal '{"new_attribute": "Time"}', @node.config
   end
 
   test 'should redirect to nodes list after update' do


### PR DESCRIPTION
On create and edit node form, the chef node config is still shown as default value.
