### PR TITLE
Updated gems for chef project

### DIFF
--- a/lib/chef_project/templates/Gemfile.lock
+++ b/lib/chef_project/templates/Gemfile.lock
@@ -34,11 +34,11 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef (12.1.1)
+    chef (12.2.0)
       chef-zero (~> 4.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
-      ffi-yajl (~> 1.2)
+      ffi-yajl (>= 1.2, < 3.0)
       highline (~> 1.6, >= 1.6.9)
       mixlib-authentication (~> 1.3)
       mixlib-cli (~> 1.4)
@@ -72,7 +72,7 @@ GEM
     erubis (2.7.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.7)
+    ffi (1.9.8)
     ffi-yajl (1.4.0)
       ffi (~> 1.5)
       libyajl2 (~> 1.2)
@@ -98,7 +98,6 @@ GEM
     mixlib-shellout (2.0.1)
     multi_json (1.11.0)
     multipart-post (2.0.0)
-    net-dhcp (1.3.2)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -111,16 +110,15 @@ GEM
     nio4r (1.1.0)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    ohai (8.1.1)
+    ohai (8.2.0)
       ffi (~> 1.9)
-      ffi-yajl (~> 1.1)
+      ffi-yajl (>= 1.1, < 3.0)
       ipaddress
       mime-types (~> 2.0)
       mixlib-cli
       mixlib-config (~> 2.0)
       mixlib-log
       mixlib-shellout (~> 2.0)
-      net-dhcp
       rake (~> 10.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
@@ -173,19 +171,19 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     semverse (1.2.1)
-    serverspec (2.10.1)
+    serverspec (2.13.0)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.15)
+      specinfra (~> 2.25)
     slop (3.6.0)
     solve (1.2.1)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
-    specinfra (2.19.4)
+    specinfra (2.27.0)
       net-scp
       net-ssh
-    systemu (2.6.4)
+    systemu (2.6.5)
     thor (0.19.1)
     timers (4.0.1)
       hitimes


### PR DESCRIPTION
Version 1.9.7 was removed from rubygems, it was broken.